### PR TITLE
app-laptop/tuxedo-keyboard: Fix kernel version

### DIFF
--- a/app-laptop/tuxedo-keyboard/tuxedo-keyboard-9999.ebuild
+++ b/app-laptop/tuxedo-keyboard/tuxedo-keyboard-9999.ebuild
@@ -36,6 +36,11 @@ pkg_setup() {
 	kernel_is -lt 3 10 0 && die "This version of ${PN} requires Linux >= 3.10"
 }
 
+src_prepare() {
+       eapply_user
+       sed -i 's!KDIR := /lib/modules/$(shell uname -r)/build!KDIR := /lib/modules/'"${KV_FULL}"'/build!g' Makefile
+}
+
 src_compile() {
 	# BUILD_PARAMS="KERNELDIR=${KERNEL_DIR}"
 	linux-mod_src_compile


### PR DESCRIPTION
Patch the Makefile replacing the running kernel version by currently enabled kernel version.
This change allow to rebuild the package after kernel upgrade and before the system is restarted