### PR TITLE
add USE flag to control vsock support in xrdp

### DIFF
--- a/net-misc/xrdp/xrdp-0.9.14.ebuild
+++ b/net-misc/xrdp/xrdp-0.9.14.ebuild
@@ -14,7 +14,7 @@ LICENSE="Apache-2.0"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 RESTRICT="mirror"
-IUSE="debug fuse kerberos jpeg -neutrinordp pam +pulseaudio systemd -xrdpvr"
+IUSE="debug fuse kerberos jpeg -neutrinordp pam +pulseaudio systemd +vsock -xrdpvr"
 
 RDEPEND="dev-libs/openssl:0=
 	pulseaudio? ( media-sound/pulseaudio:0= )
@@ -85,6 +85,7 @@ src_configure() {
 		$(usex debug --enable-xrdpdebug '')
 		$(usex fuse --enable-fuse '')
 		# $(usex neutrinordp --enable-neutrinordp '')
+		$(usex vsock --enable-vsock '')
 		# $(usex xrdpvr --enable-xrdpvr '')
 
 		--with-systemdsystemunitdir="$(systemd_get_systemunitdir)"


### PR DESCRIPTION
When running a Gentoo guest on Hyper-V, xrdp can be used to provide "Extended Session" support.
Microsoft [recommends using a vsock](https://github.com/microsoft/linux-vm-tools/blob/317a90f06ff3fe1424e8ece94b5589e26d33d8ea/arch/install-config.sh#L34) for this connection.
xrdp has vsock support, which needs to be enabled at compile-time.
This patch extends the xrdp ebuild with a USE flag to control vsock support in xrdp. The flag is enabled by default since it does not create additional dependencies and, to my knowledge, has no downsides otherwise.